### PR TITLE
Fix failing linter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Change log
 
 4.4 (unreleased)
 ----------------
+- Fix failing linter.
 
 
 4.3 (2019-05-18)

--- a/src/Products/ExternalMethod/ExternalMethod.py
+++ b/src/Products/ExternalMethod/ExternalMethod.py
@@ -122,7 +122,7 @@ class ExternalMethod(Item, Persistent, Explicit,
         self.id = id
         self.manage_edit(title, module, function)
 
-    security.declareProtected(view_management_screens,  # NOQA: flake8: D001
+    security.declareProtected(view_management_screens,  # noqa: D001
                               'manage_main')
     manage_main = DTMLFile('dtml/methodEdit', globals())
 


### PR DESCRIPTION
Flake8 recently extended its noqa syntax.

With doing so, the here used syntax was without effect.

modified:   CHANGES.rst
modified:   src/Products/ExternalMethod/ExternalMethod.py